### PR TITLE
ignore onnxruntime-gpu for macOS and for arm64 CPUs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 onnxruntime
-onnxruntime-gpu
+onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
 insightface
 numpy<2


### PR DESCRIPTION
Good day, @shiimizu 

I'm making this small pull request will be useful and will help to simplify the deployment of ComfyUI significantly with this node bundled, for projects that do it.

1. There are no binary wheels for macOS for this package and there won't be any, because the package won't work on mac.
2. There are no binary wheels for linux aarch64(arm64) either, so they are also added to ignore.

P.S: the same changes were merged to [PuLID_ComfyUI](https://github.com/cubiq/PuLID_ComfyUI) and [ComfyUI_InstantID](https://github.com/cubiq/ComfyUI_InstantID) nodes
